### PR TITLE
To be compilable with early version of OpenCV

### DIFF
--- a/Caffe_Segmentation/examples/seg/createFinalRes.cpp
+++ b/Caffe_Segmentation/examples/seg/createFinalRes.cpp
@@ -66,8 +66,8 @@ int main(int argc, char** argv) {
             LOG(ERROR) << "Unable to read image " << string(SEG_IMG_DIR) + "/" + fname;
             continue;
         }
-	resize(S, S, Size(xmax - xmin, ymax - ymin));
-	Mat extractImage = I(Rect(xmin, ymin, xmax - xmin, ymax - ymin));
+        resize(S, S, Size(xmax - xmin, ymax - ymin));
+        Mat extractImage = I(Rect(xmin, ymin, xmax - xmin, ymax - ymin));
         S.copyTo(extractImage);
         string fpath = string(OUT_DIR) + "/" + fname;
         boost::filesystem::create_directory(dirname(strdup(fpath.c_str())));


### PR DESCRIPTION
Compile the code in my machine will cause some errors like:

```
g++ examples/seg/createFinalRes.cpp -pthread -fPIC -DNDEBUG -O2 -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/usr/local/include -I.build_release/src -I./src -I./include -I/usr/local/cuda/include -Wall -Wno-sign-compare -c -o .build_release/examples/seg/createFinalRes.o 2> .build_release/examples/seg/createFinalRes.o.warnings.txt \
        || (cat .build_release/examples/seg/createFinalRes.o.warnings.txt; exit 1)
examples/seg/createFinalRes.cpp: In function ‘int main(int, char**)’:
examples/seg/createFinalRes.cpp:70:63: error: no matching function for call to ‘cv::Mat::copyTo(cv::Mat)’
examples/seg/createFinalRes.cpp:70:63: note: candidates are:
/usr/include/opencv2/core/core.hpp:1651:10: note: void cv::Mat::copyTo(cv::OutputArray) const
/usr/include/opencv2/core/core.hpp:1651:10: note:   no known conversion for argument 1 from ‘cv::Mat’ to ‘cv::OutputArray {aka const cv::_OutputArray&}’
/usr/include/opencv2/core/core.hpp:1653:10: note: void cv::Mat::copyTo(cv::OutputArray, cv::InputArray) const
/usr/include/opencv2/core/core.hpp:1653:10: note:   candidate expects 2 arguments, 1 provided
make: *** [.build_release/examples/seg/createFinalRes.o] Error 1
```

But it can fixed after a litte modifications of code like: http://stackoverflow.com/questions/10481411/opencv-copy-an-cvmat-inside-a-roi-of-another
